### PR TITLE
找到copy任务失败原因，合并master

### DIFF
--- a/tools/bundle.js
+++ b/tools/bundle.js
@@ -17,6 +17,7 @@ function bundle() {
   return new Promise((resolve, reject) => {
     webpack(webpackConfig).run((err, stats) => {
       if (err) {
+        console.log('##############', err);
         return reject(err);
       }
 

--- a/tools/copy.js
+++ b/tools/copy.js
@@ -21,7 +21,7 @@ async function copy({ watch } = {}) {
 
   await Promise.all([
     ncp('src/public', 'build/public'),
-    ncp('src/content', 'build/content'),
+    // ncp('src/content', 'build/content'),
     ncp('package.json', 'build/package.json'),
   ]);
 


### PR DESCRIPTION
由于src/content文件夹内没内容，因此git clone不到这个目录，所以当ncp拷贝这个目录时就出错，导致程序退出。
